### PR TITLE
Fix tool incompatibilites and add FuseSoC support

### DIFF
--- a/Ice40Atom.core
+++ b/Ice40Atom.core
@@ -1,0 +1,60 @@
+CAPI=1
+
+[main]
+name = ::Ice40Atom:0
+simulators = icarus modelsim
+backend = icestorm
+
+[fileset rtl]
+files =
+ src/atom.v
+ src/cpu.v
+ src/ALU.v
+ src/rom_c000_f000.v
+ src/mc6847.v
+ src/charrom.v
+ src/vid_ram.v
+ src/keyboard.v
+ src/ps2_intf.v
+ mem/charrom.mem[is_include_file]
+ mem/vid_ram.mem[is_include_file]
+file_type = verilogSource
+
+[fileset top]
+files =
+ src/bootstrap.v
+ src/spi.v
+ blackice/blackice.pcf[file_type=PCF]
+file_type = verilogSource
+
+[fileset tb]
+files = src/atom_tb.v
+file_type = verilogSource
+
+[simulator]
+toplevel = opc6tb
+
+[icestorm]
+arachne_pnr_options = -d 8k -P tq144:4k
+top_module = atom
+
+[parameter charrom_init_file]
+datatype    = str
+default     = ../src/Ice40Atom_0/mem/charrom.mem
+description = Char ROM contents
+paramtype   = vlogparam
+scope       = private
+
+[parameter vid_ram_init_file]
+datatype    = str
+default     = ../src/Ice40Atom_0/mem/vid_ram.mem
+description = Initial Video RAM contents
+paramtype   = vlogparam
+scope       = private
+
+[parameter use_sb_io]
+datatype = bool
+default = False
+description = Manually instantiate SB I/O components (required for build)
+paramtype = vlogdefine
+scope = private

--- a/src/atom.v
+++ b/src/atom.v
@@ -23,7 +23,12 @@
 // the instantaion of SB_IO (as inferrence broken)
 // `define use_sb_io
 
-module atom (
+module atom
+  #(
+    parameter charrom_init_file = "../mem/charrom.mem",
+    parameter vid_ram_init_file = "../mem/vid_ram.mem"
+    )
+   (
              // Main clock, 100MHz
              input         clk100,
              // ARM SPI slave, to bootstrap load the ROMS
@@ -390,7 +395,9 @@ module atom (
    wire [12:0] vid_addr;
    wire [7:0]  vid_data;
 
-   vid_ram VID_RAM
+   vid_ram
+     #(.MEM_INIT_FILE (vid_ram_init_file))
+   VID_RAM
      (
       // Port A
       .clk_a(!clk_cpu),    // Clock of negative edge to mask register latency
@@ -457,7 +464,9 @@ module atom (
       .char_d_o(char_d)
       );
 
-   charrom CHARROM
+   charrom
+     #(.MEM_INIT_FILE (charrom_init_file))
+   CHARROM
      (
       .clk(clk_vga),
       .address(char_a),

--- a/src/atom_tb.v
+++ b/src/atom_tb.v
@@ -1,5 +1,9 @@
 `timescale 1ns / 1ns
-module opc6tb();
+module opc6tb
+  #(
+    parameter charrom_init_file = "../mem/charrom.mem",
+    parameter vid_ram_init_file = "../mem/vid_ram.mem"
+    );
    reg [17:0]  mem [ 0:262143 ];
    
    reg         clk;
@@ -21,7 +25,12 @@ module opc6tb();
    wire        g_msb  = g[2];
    wire        b_msb  = b[1];
    
-atom DUT (
+atom
+  #(
+    .charrom_init_file (charrom_init_file),
+    .vid_ram_init_file (vid_ram_init_file)
+    )
+   DUT (
           .clk100(clk),
           .sw4(reset_b),
 

--- a/src/bootstrap.v
+++ b/src/bootstrap.v
@@ -3,7 +3,7 @@ module bootstrap
 
    // Clock needs to be clk100 (i.e. >> SCK)
    input         clk,
-   output        booting,
+   output reg    booting = 1'b1,
    output        progress,
 
    // SPI Slave Interface (runs at 20MHz)
@@ -38,7 +38,6 @@ module bootstrap
    // Local registers
    // ===============================================================
 
-   reg           booting = 1'b1;
    reg           boot_RAMWE_b;
    reg [17:0]    boot_RAMA;
    reg [7:0]     boot_RAMDin;


### PR DESCRIPTION
Three patches coming up
First allows users to override location of vid_ram and charrrom
Second reorders some reg/wires to declare them before use. This is (a stupid) requirement by ModelSim
Third adds support for building and simulating with [FuseSoC](https://github.com/olofk/fusesoc). Test with `fusesoc sim Ice40Atom` (or `fusesoc sim --sim={icarus,isim,modelsim,rivierapro,xsim} Ice40Atom` to test with a specific simulator. Build with `fusesoc build Ice40Atom`. Change parameter values by e.g. adding `--vid_ram_init_file=/path/to/file` More info with `fusesoc sim Ice40Atom --help`